### PR TITLE
updated to v1

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: eksctl.io/v1alpha5
+apiVersion: eksctl.io/v1
 kind: ClusterConfig
 
 metadata:

--- a/role.yaml
+++ b/role.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: postman-role
 rules:


### PR DESCRIPTION
In k8s 1.22 v1beta1 was updated to v1

```
$ kubectl apply -f role.yaml
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
```